### PR TITLE
Feat: allow depth map to be outputted in 2D representation

### DIFF
--- a/lidar_ouster.orogen
+++ b/lidar_ouster.orogen
@@ -15,6 +15,11 @@ task_context "Task" do
     # The sensor hostname
     property "ip_address", "/std/string"
 
+    # Property to define if the depth map will be represented in 3D or 2D
+    # If true the depth map will be outputed in 2D representation (bird's eye view)
+    # If false the depth map will be outputed in 3D representation
+    property "2d_representation", "bool"
+
     # The sensor vertical field of view in degrees
     property "vertical_fov", "double"
 


### PR DESCRIPTION
On top of: https://github.com/tidewise/drivers-orogen-lidar_ouster/pull/1