### PR TITLE
feat: add scan timeout and corresponding tests

### DIFF
--- a/lidar_ouster.orogen
+++ b/lidar_ouster.orogen
@@ -19,6 +19,12 @@ task_context "Task" do
     # If enable_remission is true, the remission will be enabled
     property "remission_enabled", "bool"
 
+    # The maximum time interval to receive a scan
+    property "scan_timeout", "base/Time"
+
+    # The maximum time interval to receive the first scan
+    property "first_scan_timeout", "base/Time"
+
     # The sensor vertical field of view in degrees
     property "vertical_fov", "double"
 
@@ -30,6 +36,8 @@ task_context "Task" do
 
     # The IMU samples data
     output_port "imu_samples", "base/samples/IMUSensors"
+
+    exception_states "TIMEOUT"
 
     periodic 0.05
 end

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -3,13 +3,13 @@
 #ifndef LIDAR_OUSTER_TASK_TASK_HPP
 #define LIDAR_OUSTER_TASK_TASK_HPP
 
-#include <lidar_ouster/TaskBase.hpp>
-#include <string>
 #include <base/samples/DepthMap.hpp>
+#include <lidar_ouster/TaskBase.hpp>
 #include <ouster/client.h>
 #include <ouster/impl/build.h>
 #include <ouster/lidar_scan.h>
 #include <ouster/types.h>
+#include <string>
 
 namespace lidar_ouster {
 
@@ -49,6 +49,8 @@ argument.
         double m_vertical_fov = 0.0;
         base::samples::DepthMap m_depth_map;
         bool m_remission_enabled = false;
+        base::Time m_first_scan_timeout;
+        base::Time m_scan_timeout;
 
     public:
         /** TaskContext constructor for Task
@@ -122,7 +124,7 @@ argument.
 
         bool configureLidar();
         ouster::sensor::sensor_info getMetadata();
-        ouster::LidarScan acquireData();
+        ouster::LidarScan acquireData(base::Time const& timeout);
         void convertDataAndWriteOutput(ouster::LidarScan& scan);
         void writeIMUSample(std::vector<uint8_t>& pkt_buffer);
         ouster::img_t<uint8_t> getReflectivity(ouster::LidarScan const& scan);


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
This objective of this PR is to add a timeout to the scan acquisition 
- [ ] [Shortcut](https://app.shortcut.com/tidewise/story/26142/add-timeout-to-component)

# How I did it
The initial scan takes a long time to be acquired, so it was moved to the
configure hook. Two timeouts were implemented, one for this first scan
acquisition and another for subsequent scan acquisitions.

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
