### PR TITLE
fix: move standby mode setting to stopHook

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -92,16 +92,16 @@ void Task::errorHook()
 void Task::stopHook()
 {
     TaskBase::stopHook();
-}
-void Task::cleanupHook()
-{
-    TaskBase::cleanupHook();
     m_handle.reset();
     sensor_config config;
     config.operating_mode = OperatingMode::OPERATING_STANDBY;
     if (!set_config(m_sensor_hostname, config, 0)) {
         LOG_ERROR_S << "Failed to configure Lidar!" << endl;
     }
+}
+void Task::cleanupHook()
+{
+    TaskBase::cleanupHook();
 }
 
 sensor_info Task::getMetadata()


### PR DESCRIPTION
# What is this PR for
Move the standby mode setting to the stopHook. The component rarely enters the cleanupHook, so the setting for standby mode has to be done in the stopHook to guarantee that the lidar enters this state whenever the component is stopped.

# Checklist
- [x] Assign yourself  in the PR