### PR TITLE
feat: create lidar ouster library and add it to orogen package

### DIFF
--- a/lidar_ouster.orogen
+++ b/lidar_ouster.orogen
@@ -3,6 +3,7 @@
 name "lidar_ouster"
 version "0.1"
 
+using_library "lidar_ouster"
 using_library "lidar_ouster_sdk"
 import_types_from "lidar_ousterTypes.hpp"
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -6,10 +6,7 @@
   <license></license>
   <url>http://</url>
   <logo>http://</logo>
-  <depend package="base/cmake" />
-
-  <depend package="drivers/lidar_ouster_sdk" />
-  <depend package="base/types" />
+  <depend package="drivers/lidar_ouster" />
   <depend package="base/logging" />
 
   <test_depend name="tools/syskit" />


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-lidar_ouster/pull/2
- [ ] https://github.com/tidewise/tidewise.common-package_set/pull/266
- [ ] https://github.com/tidewise/tidewise.wetpaint-package_set/pull/140

## What is this PR for
[sc-40704]

## How I did it
Add library to `.orogen` file and move depend packages to library.

### Checklist
- [x] Assign yourself  in the PR
