### PR TITLE
fix: fix horizontal interval fill

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -24,8 +24,8 @@ void Task::configureDepthMap()
     m_depth_map.vertical_projection = DepthMap::PROJECTION_TYPE::POLAR;
     m_depth_map.horizontal_projection = DepthMap::PROJECTION_TYPE::POLAR;
 
-    m_depth_map.horizontal_interval.push_back(M_PI * 2.0);
     m_depth_map.horizontal_interval.push_back(0);
+    m_depth_map.horizontal_interval.push_back(M_PI * 2.0);
 
     m_depth_map.vertical_interval.push_back(-(m_vertical_fov / 2) * M_PI / (180.0));
     m_depth_map.vertical_interval.push_back((m_vertical_fov / 2) * M_PI / (180.0));


### PR DESCRIPTION
# What is this PR for
Fix horizontal interval fill. The depth map was being output mirrored.
According to [Ouster documentation](https://data.ouster.io/downloads/software-user-manual/software-user-manual-v2p0.pdf):
![image](https://github.com/tidewise/drivers-orogen-lidar_ouster/assets/80434858/1c8eb350-9db0-4af8-b9e9-07392b14eb0e)
The base/DepthMap follows the right hand rule. So differently from the ouster, it fills the vector anticlockwise  
[sc-41840]

# How I did it
Inverted the order of the horizontal interval elements.


# Checklist
- [x] Assign yourself  in the PR