### PR TITLE
fix: correctly fill depth map timestamps

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -174,7 +174,7 @@ void Task::convertDataAndWriteOutput(LidarScan& scan)
 {
     auto time = base::Time::now();
     m_depth_map.time = time;
-    m_depth_map.timestamps.push_back(time);
+    m_depth_map.timestamps = { time };
 
     auto range = scan.field(ChanField::RANGE);
     auto range_destaggered =


### PR DESCRIPTION
# What is this PR for
fix: correctly fill depth map timestamps
it was increasing the size infinitely


# Checklist
- [x] Assign yourself  in the PR
